### PR TITLE
Update Next.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@tailwindcss/postcss": "^4.1.1",
     "@tanstack/react-query": "^5.90.7",
     "lucide-react": "^0.487.0",
-    "next": "15.4.8",
+    "next": "15.4.10",
     "permissionless": "^0.2.46",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -27,7 +27,7 @@
     "@types/react-dom": "^19",
     "autoprefixer": "^10.4.21",
     "eslint": "^9",
-    "eslint-config-next": "15.4.8",
+    "eslint-config-next": "15.4.10",
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.1",
     "typescript": "^5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -702,15 +702,15 @@
     "@emnapi/runtime" "^1.5.0"
     "@tybys/wasm-util" "^0.10.1"
 
-"@next/env@15.4.8":
-  version "15.4.8"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-15.4.8.tgz#f41741d07651958bccb31fb685da0303a9ef1373"
-  integrity sha512-LydLa2MDI1NMrOFSkO54mTc8iIHSttj6R6dthITky9ylXV2gCGi0bHQjVCtLGRshdRPjyh2kXbxJukDtBWQZtQ==
+"@next/env@15.4.10":
+  version "15.4.10"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-15.4.10.tgz#a794b738d043d9e98ea435bd45254899f7f77714"
+  integrity sha512-knhmoJ0Vv7VRf6pZEPSnciUG1S4bIhWx+qTYBW/AjxEtlzsiNORPk8sFDCEvqLfmKuey56UB9FL1UdHEV3uBrg==
 
-"@next/eslint-plugin-next@15.4.8":
-  version "15.4.8"
-  resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-15.4.8.tgz#032b20dec520fa8473a73b2397bbeee007e527e4"
-  integrity sha512-KYz0o9fUk2SRgxEZCWJbV3TfZ4Zxt7lAhuZ1rsHG1A9tMqTz40Zg2lHi3qtrFJ4Nw8ya6z0oR77zQiWDFo0EGg==
+"@next/eslint-plugin-next@15.4.10":
+  version "15.4.10"
+  resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-15.4.10.tgz#34b905aa84011e6707012884af1f74c4b12d516b"
+  integrity sha512-WXbIDBQ+IVnsSe5BSfOpj48pZigOp2SIaq3JcQ9DEoqm7fcSsqEFcLBU4xtnoDpWzGx4pNTchCxRcDaItO73aA==
   dependencies:
     fast-glob "3.3.1"
 
@@ -3248,12 +3248,12 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-config-next@15.4.8:
-  version "15.4.8"
-  resolved "https://registry.yarnpkg.com/eslint-config-next/-/eslint-config-next-15.4.8.tgz#79aa576c07471ecc847f41f5ae733f41b9cb3f9e"
-  integrity sha512-1cILRhcAvkAIzl6lg7dSODu2RI0RiTLpR8Z+rJLWm2W6sm9cOMTiw9ut3n/gDwDyZrLdGuWz4pkZ61BNCKdaLQ==
+eslint-config-next@15.4.10:
+  version "15.4.10"
+  resolved "https://registry.yarnpkg.com/eslint-config-next/-/eslint-config-next-15.4.10.tgz#00bf859dd65b6e8b58d400e193523892cb7bebcd"
+  integrity sha512-iJLJPTWkXlQo07mdJ+861c3I0T5UXDv9iE/dYJwceRW5a9OqXzcLwCHW4aBfOqHa0aJRWife64snHbQgLXamOA==
   dependencies:
-    "@next/eslint-plugin-next" "15.4.8"
+    "@next/eslint-plugin-next" "15.4.10"
     "@rushstack/eslint-patch" "^1.10.3"
     "@typescript-eslint/eslint-plugin" "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0"
     "@typescript-eslint/parser" "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4563,12 +4563,12 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-next@15.4.8:
-  version "15.4.8"
-  resolved "https://registry.yarnpkg.com/next/-/next-15.4.8.tgz#0f20a6cad613dc34547fa6519b2d09005ac370ca"
-  integrity sha512-jwOXTz/bo0Pvlf20FSb6VXVeWRssA2vbvq9SdrOPEg9x8E1B27C2rQtvriAn600o9hH61kjrVRexEffv3JybuA==
+next@15.4.10:
+  version "15.4.10"
+  resolved "https://registry.yarnpkg.com/next/-/next-15.4.10.tgz#4ee237d4eb16289f6e16167fbed59d8ada86aa59"
+  integrity sha512-itVlc79QjpKMFMRhP+kbGKaSG/gZM6RCvwhEbwmCNF06CdDiNaoHcbeg0PqkEa2GOcn8KJ0nnc7+yL7EjoYLHQ==
   dependencies:
-    "@next/env" "15.4.8"
+    "@next/env" "15.4.10"
     "@swc/helpers" "0.5.15"
     caniuse-lite "^1.0.30001579"
     postcss "8.4.31"


### PR DESCRIPTION
## Description 
Updates Next.js version: https://nextjs.org/blog/security-update-2025-12-11

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade Next.js to 15.4.10 and update eslint-config-next and related @next packages; refresh yarn.lock.
> 
> - **Dependencies**:
>   - **Next.js**: Bump `next` from `15.4.8` to `15.4.10`.
>   - **ESLint**: Update `eslint-config-next` to `15.4.10` and align `@next/eslint-plugin-next`.
>   - **Lockfile**: Refresh `yarn.lock` to reflect updated `@next/*` packages (e.g., `@next/env`, `next`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ef7450a1f8fd43624d3e32bf1c47cb7e3f3a4e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->